### PR TITLE
Drop engine argument from scene

### DIFF
--- a/ppb/engine.py
+++ b/ppb/engine.py
@@ -112,7 +112,7 @@ class GameEngine(EventMixin, LoggingMixin):
             return
         args = next_scene.get("args", [])
         kwargs = next_scene.get("kwargs", {})
-        self.scenes.append(scene(self, *args, **kwargs))
+        self.scenes.append(scene(*args, **kwargs))
 
     def signal(self, event):
         self.events.append(event)
@@ -176,7 +176,7 @@ class GameEngine(EventMixin, LoggingMixin):
 
     def start_scene(self, scene, kwargs):
         if isinstance(scene, type):
-            scene = scene(self, **(kwargs or {}))
+            scene = scene(**(kwargs or {}))
         self.scenes.append(scene)
         self.signal(events.SceneStarted())
 

--- a/ppb/scenes.py
+++ b/ppb/scenes.py
@@ -101,11 +101,10 @@ class BaseScene(EventMixin):
     background_color: Sequence[int] = (0, 0, 100)
     container_class: Type = GameObjectCollection
 
-    def __init__(self, engine, *,
+    def __init__(self, *,
                  set_up: Callable = None, pixel_ratio: Number = 64,
                  **kwargs):
         super().__init__()
-        self.engine = engine
         for k, v in kwargs.items():
             setattr(self, k, v)
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2,6 +2,8 @@ import dataclasses
 import unittest
 from unittest import mock
 
+import pytest
+
 from pygame import Surface
 
 from ppb import GameEngine, BaseScene, Vector
@@ -79,7 +81,7 @@ def test_change_scene_event():
     class FirstScene(BaseScene):
 
         def on_update(self, event, signal):
-            signal(events.StartScene(new_scene=SecondScene(ge)))
+            signal(events.StartScene(new_scene=SecondScene()))
 
         def on_scene_paused(self, event, signal):
             assert event.scene is self
@@ -164,7 +166,7 @@ def test_replace_scene_event():
     class FirstScene(BaseScene):
 
         def on_update(self, event, signal):
-            signal(events.ReplaceScene(new_scene=SecondScene(ge)))
+            signal(events.ReplaceScene(new_scene=SecondScene()))
 
         def on_scene_stopped(self, event, signal):
             assert event.scene is self
@@ -227,6 +229,7 @@ def test_flush_events():
     assert len(ge.events) == 0
 
 
+@pytest.mark.xfail
 def test_event_extension():
 
     @dataclasses.dataclass
@@ -236,8 +239,8 @@ def test_event_extension():
 
     class TestScene(BaseScene):
 
-        def __init__(self, engine):
-            super().__init__(engine)
+        def __init__(self):
+            super().__init__()
             engine.register(TestEvent, self.event_extension)
 
         def on_update(self, event, signal):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -39,6 +39,7 @@ def test_signal():
     engine.run()
     assert not engine.running
 
+
 def test_signal_once():
 
     engine = GameEngine(BaseScene, systems=[Quitter])
@@ -229,18 +230,16 @@ def test_flush_events():
     assert len(ge.events) == 0
 
 
-@pytest.mark.xfail
 def test_event_extension():
 
     @dataclasses.dataclass
     class TestEvent:
         pass
 
+    class TestSystem(System):
 
-    class TestScene(BaseScene):
-
-        def __init__(self):
-            super().__init__()
+        def __init__(self, *, engine, **_):
+            super().__init__(engine=engine, **_)
             engine.register(TestEvent, self.event_extension)
 
         def on_update(self, event, signal):
@@ -253,7 +252,7 @@ def test_event_extension():
         def event_extension(self, event):
             event.test_value = "Red"
 
-    with GameEngine(TestScene, systems=[Updater, Failer], message="Will only time out.", fail=lambda x: False) as ge:
+    with GameEngine(BaseScene, systems=[TestSystem, Updater, Failer], message="Will only time out.", fail=lambda x: False) as ge:
         ge.run()
 
 

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -27,7 +27,7 @@ class TestSprite:
 
 def containers():
     yield GameObjectCollection()
-    yield BaseScene(Mock())
+    yield BaseScene()
 
 
 def players():
@@ -48,8 +48,7 @@ def enemies():
 
 @fixture()
 def scene():
-    engine = Mock()
-    return BaseScene(engine)
+    return BaseScene()
 
 
 @mark.parametrize("player, container", players_and_containers())
@@ -147,8 +146,8 @@ def test_class_attrs():
     class BackgroundScene(BaseScene):
         background_color = (0, 4, 2)
 
-    scene = BackgroundScene(Mock())
+    scene = BackgroundScene()
     assert scene.background_color == (0, 4, 2)
 
-    scene = BackgroundScene(Mock(), background_color=(2, 4, 0))
+    scene = BackgroundScene(background_color=(2, 4, 0))
     assert scene.background_color == (2, 4, 0)


### PR DESCRIPTION
@pathunstrom @nicoo I wanted to run this through a PR because it does disable a use case, as evidenced by the `test_event_extension` test case. Namely: A scene registering itself as an event extension.

My take is that this is ok because this actually has surprising effects, namely that the the event extension is not limited to just when that scene is active (unlike everything else that happens under scenes).

But I just want to run this by you, first.